### PR TITLE
Collapse all except the first sidebar category by default

### DIFF
--- a/src/editor/components/ItemPanel.tsx
+++ b/src/editor/components/ItemPanel.tsx
@@ -76,6 +76,7 @@ export const ItemPanel: React.FunctionComponent<IProps> = (props) => {
         };
       }
     );
+    // collapse all except first by default
     treeNodes[0].expanded = true;
     setTreeData(treeNodes);
   }


### PR DESCRIPTION
Design will be updated in the future to better reflect collapsed/open status

![image](https://user-images.githubusercontent.com/66746699/88300667-5e408180-ccc9-11ea-8092-0d81890acc97.png)
