### PR TITLE
Disconnect mutation observer on unmount

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./App.css";
-import React from "react";
+import React, { useEffect } from "react";
 import { ThemeProvider } from "office-ui-fabric-react/lib/Foundation";
 import { ITheme } from "office-ui-fabric-react";
 import ThemeHelpers from "./helpers/ThemeHelpers";
@@ -22,8 +22,15 @@ export const App: React.FunctionComponent<IProps> = (props) => {
   const [theme, setTheme] = React.useState<ITheme>(
     ThemeHelpers.getAdaptedTheme()
   );
-  ThemeHelpers.attachHtmlStyleAttrListener(() => {
+  const observer = ThemeHelpers.attachHtmlStyleAttrListener(() => {
     setTheme(ThemeHelpers.getAdaptedTheme());
+  });
+
+  // when unmounting, disconnect the observer to prevent leaked references
+  useEffect(() => {
+    return () => {
+      observer.disconnect();
+    };
   });
 
   const graph = new Graph();

--- a/src/helpers/ThemeHelpers.ts
+++ b/src/helpers/ThemeHelpers.ts
@@ -43,12 +43,14 @@ export default class ThemeHelpers {
     });
   }
 
-  static attachHtmlStyleAttrListener(callback: () => void) {
-    new MutationObserver(() => {
+  static attachHtmlStyleAttrListener(callback: () => void): MutationObserver {
+    const observer = new MutationObserver(() => {
       callback();
-    }).observe(document.documentElement, {
+    });
+    observer.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ["style"],
     });
+    return observer;
   }
 }


### PR DESCRIPTION
When running in VS Code and repeatedly changing themes, additional mutation observers are created that are not cleaned up. The changes in this PR disconnect the mutation observer on unmount of the App component to improve performance.