### PR TITLE
Update GraphValidationRules.ts

### DIFF
--- a/src/Webview/Models/GraphValidationRules.ts
+++ b/src/Webview/Models/GraphValidationRules.ts
@@ -8,6 +8,8 @@ export default class GraphValidationRules {
     ];
 
     static mustBeImmediatelyDownstreamOf = [
+        // Motion detection processor: Must be immediately downstream from RTSP source.
+        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", ["#Microsoft.Media.MediaGraphRtspSource"]],
         // Signal gate processor: Must be immediately downstream from RTSP source.
         ["#Microsoft.Media.MediaGraphSignalGateProcessor", ["#Microsoft.Media.MediaGraphRtspSource"]],
         // Asset sink: Must be immediately downstream from RTSP source or signal gate processor.

--- a/src/Webview/Models/GraphValidationRules.ts
+++ b/src/Webview/Models/GraphValidationRules.ts
@@ -5,15 +5,9 @@ export default class GraphValidationRules {
     static limitOnePerGraph = [
         // Only one RTSP source is allowed per graph topology.
         "#Microsoft.Media.MediaGraphRtspSource",
-        // HTTP extension processor: There can be at most one such processor per graph topology.
-        "#Microsoft.Media.MediaGraphHttpExtension",
-        // Motion detection processor: There can be at most one such processor per graph topology.
-        "#Microsoft.Media.MediaGraphMotionDetectionProcessor"
     ];
 
     static mustBeImmediatelyDownstreamOf = [
-        // Frame rate filter processor: Must be immediately downstream from RTSP source or motion detection processor.
-        ["#Microsoft.Media.MediaGraphFrameRateFilterProcessor", ["#Microsoft.Media.MediaGraphRtspSource", "#Microsoft.Media.MediaGraphMotionDetectionProcessor"]],
         // Motion detection processor: Must be immediately downstream from RTSP source.
         ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", ["#Microsoft.Media.MediaGraphRtspSource"]],
         // Signal gate processor: Must be immediately downstream from RTSP source.
@@ -34,13 +28,13 @@ export default class GraphValidationRules {
     ];
 
     static cannotBeDownstreamOf = [
-        // Frame rate filter processor: Cannot be used downstream of a HTTP extension processor.
-        ["#Microsoft.Media.MediaGraphFrameRateFilterProcessor", "#Microsoft.Media.MediaGraphHttpExtension"],
-        // Frame rate filter processor: Cannot be upstream from a motion detection processor.
-        // note the flipped order as this is an upstream rule
-        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", "#Microsoft.Media.MediaGraphFrameRateFilterProcessor"],
-        // Motion detection processor: Cannot be used downstream of a HTTP extension processor.
-        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", "#Microsoft.Media.MediaGraphHttpExtension"]
+        // Motion detection processor: Cannot be used downstream of a graph extension processor.
+        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", "#Microsoft.Media.MediaGraphHttpExtension"],
+        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", "#Microsoft.Media.MediaGraphGrpcExtension"],
+        // Motion detection processors cannot be in sequence
+        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", "#Microsoft.Media.MediaGraphMotionDetectionProcessor"],
+        // Signal gate processors cannot be in sequence
+        ["#Microsoft.Media.MediaGraphSignalGateProcessor", "#Microsoft.Media.MediaGraphSignalGateProcessor"]
     ];
 
     static documentationLinks = {

--- a/src/Webview/Models/GraphValidationRules.ts
+++ b/src/Webview/Models/GraphValidationRules.ts
@@ -8,8 +8,6 @@ export default class GraphValidationRules {
     ];
 
     static mustBeImmediatelyDownstreamOf = [
-        // Motion detection processor: Must be immediately downstream from RTSP source.
-        ["#Microsoft.Media.MediaGraphMotionDetectionProcessor", ["#Microsoft.Media.MediaGraphRtspSource"]],
         // Signal gate processor: Must be immediately downstream from RTSP source.
         ["#Microsoft.Media.MediaGraphSignalGateProcessor", ["#Microsoft.Media.MediaGraphRtspSource"]],
         // Asset sink: Must be immediately downstream from RTSP source or signal gate processor.


### PR DESCRIPTION
Cannot be represented:
- Exactly one rtsp source must be present
- Gated asset/file sinks must contain some dynamic variable in their file/asset name. (Like `${System.DateTime}`)